### PR TITLE
Remove BOM from Excel-generated CSV

### DIFF
--- a/iiif/legacy-iiif-manifests.csv
+++ b/iiif/legacy-iiif-manifests.csv
@@ -1,4 +1,4 @@
-﻿holding_institution,shelfmark,iiif_manifest_url
+holding_institution,shelfmark,iiif_manifest_url
 csl,MS 10,https://iiif.archivelab.org/iiif/images_SutroCollectionMS10_12/manifest.json
 csl,MS 08,https://iiif.archivelab.org/iiif/images_SutroCollectionMS08_12/manifest.json
 csl,MS 07,https://iiif.archivelab.org/iiif/images_SutroCollectionMS07_12/manifest.json


### PR DESCRIPTION
File exported from Excel using "Save As UTF-8 CSV". This adds a BOM as first character, which breaks accessing first column of CSV by its header name -- as the first header name in the file now starts with an invisible BOM character. `dos2unix` removed it.