### PR TITLE
Prepend Sutro Collection to select CSL call nos.

### DIFF
--- a/iiif/legacy-iiif-manifests.csv
+++ b/iiif/legacy-iiif-manifests.csv
@@ -1,39 +1,39 @@
 holding_institution,shelfmark,iiif_manifest_url
-csl,MS 10,https://iiif.archivelab.org/iiif/images_SutroCollectionMS10_12/manifest.json
-csl,MS 08,https://iiif.archivelab.org/iiif/images_SutroCollectionMS08_12/manifest.json
-csl,MS 07,https://iiif.archivelab.org/iiif/images_SutroCollectionMS07_12/manifest.json
-csl,MS 06,https://iiif.archivelab.org/iiif/images_SutroCollectionMS06_12/manifest.json
-csl,MS 05,https://iiif.archivelab.org/iiif/images_SutroCollectionMS05_12/manifest.json
-csl,MS 04,https://iiif.archivelab.org/iiif/images_SutroCollectionMS04_12/manifest.json
-csl,MS 02,https://iiif.archivelab.org/iiif/images_SutroCollectionMS02_12/manifest.json
-csl,MS 01,https://iiif.archivelab.org/iiif/images_SutroCollectionMS01_12/manifest.json
-csl,Italian Manuscripts 167,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts167_12/manifest.json
-csl,Italian Manuscripts 166,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts166_12/manifest.json
-csl,Italian Manuscripts 164,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts164_12/manifest.json
-csl,Italian Manuscripts 163,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts163_12/manifest.json
-csl,Italian Manuscripts 129,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts129_12/manifest.json
-csl,Italian Manuscripts 128,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts128_12/manifest.json
-csl,Italian Manuscripts 127,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts127_12/manifest.json
-csl,Italian Manuscripts 126,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts126_12/manifest.json
-csl,Italian Manuscripts 125,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts125_12/manifest.json
-csl,Italian Manuscripts 123,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts123_12/manifest.json
-csl,Italian Manuscripts 121,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts121_12/manifest.json
-csl,Italian Manuscripts 098,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts098_12/manifest.json
-csl,Italian Manuscripts 089,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts089_12/manifest.json
-csl,Italian Manuscripts 051,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts051_12/manifest.json
-csl,Italian Manuscripts 049,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts049_12/manifest.json
-csl,Italian Manuscripts 048,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts048_12/manifest.json
-csl,Italian Manuscripts 045,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts045_12/manifest.json
-csl,Italian Manuscripts 043,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts043_12/manifest.json
-csl,Italian Manuscripts 042,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts042_12/manifest.json
-csl,Italian Manuscripts 041,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts041_12/manifest.json
-csl,Italian Manuscripts 040,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts040_12/manifest.json
-csl,Italian Manuscripts 031,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts031_12/manifest.json
-csl,Italian Manuscripts 021,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts021_12/manifest.json
-csl,Halliwell Phillips MS 04,https://iiif.archivelab.org/iiif/images_SutroCollectionHalliwellPhillipsMS04_12/manifest.json
-csl,Halliwell Phillips MS 03,https://iiif.archivelab.org/iiif/images_SutroCollectionHalliwellPhillipsMS03_12/manifest.json
-csl,Halliwell Phillips MS 02,https://iiif.archivelab.org/iiif/images_SutroCollectionHalliwellPhillipsMS02_12/manifest.json
-csl,Halliwell Phillips MS 01,https://iiif.archivelab.org/iiif/images_SutroCollectionHalliwellPhillipsMS01_12/manifest.json
+csl,Sutro Collection MS 10,https://iiif.archivelab.org/iiif/images_SutroCollectionMS10_12/manifest.json
+csl,Sutro Collection MS 08,https://iiif.archivelab.org/iiif/images_SutroCollectionMS08_12/manifest.json
+csl,Sutro Collection MS 07,https://iiif.archivelab.org/iiif/images_SutroCollectionMS07_12/manifest.json
+csl,Sutro Collection MS 06,https://iiif.archivelab.org/iiif/images_SutroCollectionMS06_12/manifest.json
+csl,Sutro Collection MS 05,https://iiif.archivelab.org/iiif/images_SutroCollectionMS05_12/manifest.json
+csl,Sutro Collection MS 04,https://iiif.archivelab.org/iiif/images_SutroCollectionMS04_12/manifest.json
+csl,Sutro Collection MS 02,https://iiif.archivelab.org/iiif/images_SutroCollectionMS02_12/manifest.json
+csl,Sutro Collection MS 01,https://iiif.archivelab.org/iiif/images_SutroCollectionMS01_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 167,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts167_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 166,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts166_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 164,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts164_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 163,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts163_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 129,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts129_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 128,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts128_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 127,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts127_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 126,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts126_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 125,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts125_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 123,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts123_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 121,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts121_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 098,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts098_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 089,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts089_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 051,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts051_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 049,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts049_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 048,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts048_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 045,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts045_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 043,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts043_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 042,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts042_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 041,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts041_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 040,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts040_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 031,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts031_12/manifest.json
+csl,Sutro Collection Italian Manuscripts 021,https://iiif.archivelab.org/iiif/images_SutroCollectionItalianManuscripts021_12/manifest.json
+csl,Sutro Collection Halliwell Phillips MS 04,https://iiif.archivelab.org/iiif/images_SutroCollectionHalliwellPhillipsMS04_12/manifest.json
+csl,Sutro Collection Halliwell Phillips MS 03,https://iiif.archivelab.org/iiif/images_SutroCollectionHalliwellPhillipsMS03_12/manifest.json
+csl,Sutro Collection Halliwell Phillips MS 02,https://iiif.archivelab.org/iiif/images_SutroCollectionHalliwellPhillipsMS02_12/manifest.json
+csl,Sutro Collection Halliwell Phillips MS 01,https://iiif.archivelab.org/iiif/images_SutroCollectionHalliwellPhillipsMS01_12/manifest.json
 csl,CSL v096 C3631,https://iiif.archivelab.org/iiif/images_CSLv096C3631_9/manifest.json
 csl,CSL v091 B29,https://iiif.archivelab.org/iiif/images_CSLv091B29_9/manifest.json
 conception,CA 43,https://iiif.archivelab.org/iiif/images_CA43_15/manifest.json
@@ -112,7 +112,7 @@ indiana,Adomeit 21,https://iiif.archivelab.org/iiif/images_Adomeit21_40/manifest
 indiana,Adomeit 48,https://iiif.archivelab.org/iiif/images_Adomeit48_40/manifest.json
 indiana,Adomeit 9,https://iiif.archivelab.org/iiif/images_Adomeit9_40/manifest.json
 indiana,Allen 7,https://iiif.archivelab.org/iiif/images_Allen7_40/manifest.json
-indiana,Ege 15 ,https://iiif.archivelab.org/iiif/images_Ege15_40/manifest.json
+indiana,Ege 15,https://iiif.archivelab.org/iiif/images_Ege15_40/manifest.json
 indiana,Gottfried Mss.,https://iiif.archivelab.org/iiif/images_GottfriedMss_40/manifest.json
 indiana,Medieval and Renaissance 14,https://iiif.archivelab.org/iiif/images_MedievalandRenaissance14_40/manifest.json
 indiana,Medieval and Renaissance 15,https://iiif.archivelab.org/iiif/images_MedievalandRenaissance15_40/manifest.json


### PR DESCRIPTION
Most CSL call numbers in the IIIF manifests CSV do not match the ones extracted by ds-convert. This fix aligns them thus:

Prepended Sutro Collection to select CSL call nos. These are the ones that begin: MS, Italian Manuscripts, and Halliwell Phillips